### PR TITLE
Correct "Viet Nam" to "Vietnam"

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -235,7 +235,7 @@
   "VE": "Venezuela",
   "VG": "Virgin Islands, British",
   "VI": "Virgin Islands, U.S.",
-  "VN": "Viet Nam",
+  "VN": "Vietnam",
   "VU": "Vanuatu",
   "WF": "Wallis and Futuna",
   "WS": "Samoa",


### PR DESCRIPTION
Based on https://en.wikipedia.org/wiki/ISO_3166-2:VN