### PR TITLE
Move DPR Korea specifier to end

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -118,7 +118,7 @@
   "KI": ["Kiribati", "I-Kiribati"],
   "KM": ["Comoros", "Comoran"],
   "KN": ["Saint Kitts and Nevis", "Kittitian or Nevisian"],
-  "KP": ["Democratic People's Republic of Korea", "North Korea", "North Korean"],
+  "KP": ["Korea, Democratic People's Republic of", "North Korea", "North Korean"],
   "KR": ["Korea, Republic of", "South Korea", "South Korean"],
   "KW": ["Kuwait", "Kuwaiti"],
   "KY": ["Cayman Islands", "Caymanian"],


### PR DESCRIPTION
Changed DPR Korea long name to match other countries such as "Macedonia, The Former Yugoslav Republic of". Feel free to reject if this was intentional to keep North and South Korea from being next to each other in sort order.