### PR TITLE
Add Macau Naming to Macao

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -144,7 +144,7 @@
   "ML": ["Mali", "Malian"],
   "MM": ["Myanmar", "Burma", "Burmese"],
   "MN": ["Mongolia", "Mongolian"],
-  "MO": ["Macao", "Macanese"],
+  "MO": ["Macao", "Macau", "Macanese"],
   "MP": ["Northern Mariana Islands"],
   "MQ": ["Martinique"],
   "MR": ["Mauritania", "Mauritanian"],


### PR DESCRIPTION
`Macao` is often spelled `Macau` as well - this PR adds the `Macau` spelling to the list.