### PR TITLE
Fix São Tomé and Príncipe

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -209,7 +209,7 @@
   "SO": ["Somalia", "Somali"],
   "SR": ["Suriname", "Surinamer"],
   "SS": ["Republic of South Sudan", "South Sudan", "South Sudanese"],
-  "ST": ["Sao Tome and Principe", "Sao Tomean"],
+  "ST": ["Sao Tome and Principe", "São Tomé and Príncipe", "São Tome and Principe", "Sao Tomean"],
   "SV": ["El Salvador", "Salvadoran"],
   "SX": ["Sint Maarten", "Sint Maartener"],
   "SY": ["Syrian Arab Republic", "Syrian"],


### PR DESCRIPTION
The real name is `São Tomé and Príncipe`.

`Sao Tome and Principe` has missing some punctuations