### PR TITLE
Add Democratic Republic of the Congo alias

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -40,7 +40,7 @@
   "BZ": ["Belize", "Belizean"],
   "CA": ["Canada", "Canadian"],
   "CC": ["Cocos (Keeling) Islands", "Cocos Islander"],
-  "CD": ["Congo, The Democratic Republic of the"],
+  "CD": ["Congo, The Democratic Republic of the", "Democratic Republic of the Congo"],
   "CF": ["Central African Republic", "Central African"],
   "CG": ["Congo"],
   "CH": ["Switzerland", "Swiss"],

--- a/test/code.js
+++ b/test/code.js
@@ -44,6 +44,11 @@ test('converts weird name notation', t => {
 	t.is(iso3166, 'IR', 'Should return IR for Iran, Islamic Republic Of');
 });
 
+test('converts Democratic Republic of the Congo', t => {
+	const iso3166 = code('Democratic Republic of the Congo');
+	t.is(iso3166, 'CD', 'Should return CD for Democratic Republic of the Congo');
+});
+
 test('converts new macedonian name', t => {
 	const iso3166 = code('The Former Yugoslav Republic of Macedonia');
 	t.is(iso3166, 'MK', 'Should return MK for The Former Yugoslav Republic of Macedonia');


### PR DESCRIPTION
## Summary
- add Democratic Republic of the Congo as an exact CD alias
- cover the common-name lookup with a regression test

## Rationale
normalizeOutput() already rotates Congo, The Democratic Republic of the to The Democratic Republic of the Congo for display, and fuzzy matching can find that normalized form. The lookup still returns undefined on master because fuzzy matching also matches CG through its shorter Congo alias, so nameToCode() sees more than one match and intentionally refuses the ambiguous result. This exact alias lets the common country name resolve before the fuzzy ambiguity pass.

## Validation
- npm test

AI-generated PR.