### PR TITLE
Support Saint name abbreviations

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -30,6 +30,9 @@ export function normalizeName(name) {
 	// Replace & with and
 	name = name.replaceAll(/\s*&\s*/g, ' and ');
 
+	// Replace common Saint abbreviation
+	name = name.replaceAll(/\bst\.?\s+/gi, 'saint ');
+
 	// Replace diacritics with their base characters
 	name = name.normalize('NFD').replaceAll(/[\u0300-\u036F]/g, '');
 

--- a/test/flag.js
+++ b/test/flag.js
@@ -29,6 +29,11 @@ test('converts short name', t => {
 	t.is(emoji, '🇬🇧', 'Should return 🇬🇧 for UK');
 });
 
+test('converts Saint abbreviation', t => {
+	const emoji = flag('St Kitts & Nevis');
+	t.is(emoji, '🇰🇳', 'Should return 🇰🇳 for St Kitts & Nevis');
+});
+
 test('converts partial name', t => {
 	const emoji = flag('Czech');
 	t.is(emoji, '🇨🇿', 'Should return 🇨🇿 for Czechia');


### PR DESCRIPTION
## Summary
- normalize common St/St. prefixes to Saint during name matching
- cover Google-style short country names like St Kitts & Nevis

## Validation
- npm test
- npm run lint
- npm run build

AI-generated PR.