### PR TITLE
Preserve ES modules in build output

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["@babel/preset-env"],
+  "presets": [["@babel/preset-env", {"modules": false}]],
   "plugins": ["@babel/plugin-syntax-import-attributes"]
 }


### PR DESCRIPTION
## Summary
- configure Babel to preserve ESM syntax instead of emitting CommonJS
- keep generated dist output aligned with package.json type: module

## Validation
- npm test
- npm run lint
- npm run build
- node --input-type=module import from ./dist/main.js

AI-generated PR.