### PR TITLE
Add Sark country data

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -51,6 +51,7 @@
   "CN": ["China", "Chinese"],
   "CO": ["Colombia", "Colombian"],
   "CP": ["Clipperton Island"],
+  "CQ": ["Sark"],
   "CR": ["Costa Rica", "Costa Rican"],
   "CU": ["Cuba", "Cuban"],
   "CV": ["Cape Verde", "Cape Verdian"],

--- a/test/name.js
+++ b/test/name.js
@@ -52,6 +52,11 @@ test('returns correct name for Macedonian country code', t => {
 	t.is(country, 'Republic of North Macedonia', 'Should return correct name for code MK');
 });
 
+test('returns name for Sark country code', t => {
+	const country = name('CQ');
+	t.is(country, 'Sark', 'Should return Sark for code CQ');
+});
+
 test('returns name with diacritics for code TR', t => {
 	const country = name('TR');
 	t.is(country, 'Türkiye', 'Should return correct name for code TR');


### PR DESCRIPTION
## Summary
- add Sark under the CQ flag sequence
- cover the CQ code-to-name lookup with a regression test

## Rationale
Unicode Emoji 16.0 now lists 1F1E8 1F1F6 as flag: Sark, so this follows the existing project direction of including available flag sequences.

## Validation
- npm test

AI-generated PR.